### PR TITLE
Fix STARTED action to send payload as an object, not array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export function createActionThunk(type, asyncFunction) {
     let result
     let startedAt = new Date().getTime()
 
-    dispatch(actionCreators[TYPE_STARTED](args))
+    dispatch(actionCreators[TYPE_STARTED](...args))
 
     const succeeded = (data) => {
       const successAction = data && data.payload ? successActionWithMeta(data) : actionCreators[TYPE_SUCCEEDED](data)


### PR DESCRIPTION
Currently the `payload` for the STARTED action is being sent as an array

```ts
payload: [
  {},
]
```

It's missing a spread in args (`...args`)